### PR TITLE
Dont fail on empty munin data

### DIFF
--- a/lib/munin-ruby/stat.rb
+++ b/lib/munin-ruby/stat.rb
@@ -1,19 +1,22 @@
 module Munin
   class Stat
     attr_reader :name, :params
-    
+
     # Initialize a new Munin::Stat object
     #
     # name - Attribute name
     # rows - Array of parameters
     #
-    def initialize(name, rows=[])    
+    def initialize(name, rows=[])
       @name = name
       @params = {}
       unless rows.empty?
         rows.each do |r|
-          key = r.first.split('.value').first
-          @params[key] = r.last
+          begin
+            key = r.first.split('.value').first
+            @params[key] = r.last
+          rescue
+          end
         end
       end
     end


### PR DESCRIPTION
Munin sometimes return empty or weird data that would cause the
collection to bail out completely.  This just catches the exceptions
and treat bad data like noop
