### PR TITLE
There was a bug when a node name contains a - in the name

### DIFF
--- a/lib/munin-ruby/cache.rb
+++ b/lib/munin-ruby/cache.rb
@@ -20,7 +20,7 @@ module Munin
     protected
     
     def cache_key(key)
-      "@cache_#{key.gsub('.','__')}".to_sym
+      "@cache_#{key.gsub(/[\.-]/,'__')}".to_sym
     end
       
     def cache_get(key)


### PR DESCRIPTION
The character - is allowed in the RFC of hostnames. In order to allow them, given that - is not a valid variable name a substitution has to be made.

Thanks for your work!
